### PR TITLE
Slow down correct motor when turning

### DIFF
--- a/picarx/picarx.py
+++ b/picarx/picarx.py
@@ -181,14 +181,14 @@ class Picarx(object):
             if abs_current_angle > self.DIR_MAX:
                 abs_current_angle = self.DIR_MAX
             power_scale = (100 - abs_current_angle) / 100.0 
-            if (current_angle / abs_current_angle) > 0:
-                self.set_motor_speed(1, -1*speed)
+            if current_angle > 0:
+                self.set_motor_speed(1, -speed)
                 self.set_motor_speed(2, speed * power_scale)
             else:
-                self.set_motor_speed(1, -1*speed * power_scale)
+                self.set_motor_speed(1, -speed * power_scale)
                 self.set_motor_speed(2, speed )
         else:
-            self.set_motor_speed(1, -1*speed)
+            self.set_motor_speed(1, -speed)
             self.set_motor_speed(2, speed)  
 
     def forward(self, speed):
@@ -198,15 +198,15 @@ class Picarx(object):
             if abs_current_angle > self.DIR_MAX:
                 abs_current_angle = self.DIR_MAX
             power_scale = (100 - abs_current_angle) / 100.0
-            if (current_angle / abs_current_angle) > 0:
-                self.set_motor_speed(1, 1*speed * power_scale)
-                self.set_motor_speed(2, -speed) 
-            else:
+            if current_angle > 0:
                 self.set_motor_speed(1, speed)
-                self.set_motor_speed(2, -1*speed * power_scale)
+                self.set_motor_speed(2, -speed * power_scale)
+            else:
+                self.set_motor_speed(1, speed * power_scale)
+                self.set_motor_speed(2, -speed)
         else:
             self.set_motor_speed(1, speed)
-            self.set_motor_speed(2, -1*speed)                  
+            self.set_motor_speed(2, -speed)
 
     def stop(self):
         '''


### PR DESCRIPTION
When moving forward, slow down the left motor when turning left and the right motor when turning right.