### PR TITLE
Add OpenClaw PiCar-X control skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 build/*
 bk/
 *secret*
+.vscode
+build*
+.vscode/
+photo
+test/photo*
+test/scene/*
+backups/*
+**secret*
+.claude/

--- a/picarx-control/SKILL.md
+++ b/picarx-control/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: picarx-control
+description: "Control a SunFounder PiCar-X robot car: drive, steer, sense, camera gimbal, play sounds, camera vision."
+homepage: https://docs.sunfounder.com/projects/picar-x/en/latest/
+metadata:
+  openclaw:
+    emoji: "🚗"
+    requires:
+      bins: ["python3"]
+      python: ["picarx", "robot_hat", "vilib"]
+---
+
+# PiCar-X Control Skill
+
+You are controlling a **PiCar-X** robot car — a Raspberry Pi with 2 rear drive motors, a front steering servo, a 2-axis camera gimbal (pan/tilt), an ultrasonic distance sensor, a 3-channel grayscale module, and a PiCamera with speaker.
+
+When the user talks to you in natural language ("drive forward", "turn left", "check if there's an obstacle ahead"), use `exec` to run Python code on the robot's Raspberry Pi. Examples below show exactly what to exec.
+
+## Safety Rules — Always Follow These
+
+1. **Start slow**: Use speed=30 for testing, 50 for normal driving, 80 max. Reduce speed when turning.
+2. **Stop after each action**: Always call `car.stop()` after completing a movement sequence.
+3. **Check surroundings first**: If the user asks to move, consider checking the ultrasonic distance first.
+4. **Flat surface**: Ensure the car is on a flat, clear surface before driving.
+5. **Don't run multiple moves simultaneously**: Wait for one action (including delays) to finish before starting the next.
+6. **Steering angle**: Keep between -30 and 30. Use smaller angles (15-20) at higher speeds.
+
+## ⚠️ Grayscale Sensor ADC Poisoning — Quick Rules
+
+`Picarx.__init__()` calls `reset_mcu()`, which reboots the Robot HAT's STM32 co-processor. If this happens AFTER ADC objects already exist, the ADC is poisoned and returns fake values **`[2571, 3085, 3599]`** forever. Real readings are **0–2000** with slight variation between reads.
+
+**Two simple rules to avoid poisoning entirely:**
+
+| If you need... | Do this | Poison risk |
+|---|---|---|
+| Only grayscale (no movement) | Just create `Grayscale_Module` with `ADC`. Don't import Picarx. | Zero |
+| Movement + grayscale (e.g. line tracking) | Create `Picarx` FIRST, then create `Grayscale_Module` with fresh `ADC` objects after. | Zero |
+
+```python
+# ✅ Only grayscale — no Picarx at all
+from robot_hat import ADC, Grayscale_Module
+gs = Grayscale_Module(ADC("A0"), ADC("A1"), ADC("A2"), reference=[1000, 1000, 1000])
+
+# ✅ Movement + grayscale — Picarx FIRST, then ADC
+from picarx import Picarx
+from robot_hat import ADC, Grayscale_Module
+car = Picarx()                                                              # ← reset_mcu happens here
+gs = Grayscale_Module(ADC("A0"), ADC("A1"), ADC("A2"), reference=[1000, 1000, 1000])  # ← safe: ADC created after
+
+# ❌ ADC before Picarx — WILL be poisoned
+gs = Grayscale_Module(ADC("A0"), ADC("A1"), ADC("A2"), reference=[1000, 1000, 1000])
+car = Picarx()  # ← reset_mcu kills the existing ADC!
+```
+
+**Safety net**: As a final safeguard, always validate the first reading. If it's `[2571, 3085, 3599]`, discard and re-create the `Grayscale_Module` with fresh `ADC` objects.
+
+## Recognition Mapping — What the User Said → What You Run
+
+| User says... | You should exec... |
+|---|---|
+| "drive forward / go forward / move ahead" | `car.forward(speed) → sleep → car.stop()` |
+| "go backward / reverse / move back" | `car.backward(speed) → sleep → car.stop()` |
+| "turn left" | `car.set_dir_servo_angle(-30) → drive forward briefly → straighten → stop` |
+| "turn right" | `car.set_dir_servo_angle(30) → drive forward briefly → straighten → stop` |
+| "look left" | `car.set_cam_pan_angle(60)` |
+| "look right" | `car.set_cam_pan_angle(-60)` |
+| "look up" | `car.set_cam_tilt_angle(40)` |
+| "look down" | `car.set_cam_tilt_angle(-20)` |
+| "look straight / look ahead" | `car.set_cam_pan_angle(0) + car.set_cam_tilt_angle(0)` |
+| "is there something ahead / measure distance" | `exec ultrasonic read, return the value to user` |
+| "make a sound / honk / play sound" | `music.sound_play(path) or music.music_play(path)` |
+| "take a photo / take a picture" | `Vilib.take_photo() → tell user where it saved` |
+| "detect faces / look at me" | `Vilib.face_detect_switch(True) → read result → tell user` |
+| "find red / find blue / locate color..." | `Vilib.color_detect('red') → read coordinates → tell user` |
+| "follow the line" | ⚠️ Create Grayscale_Module for sensor + Picarx for movement. Validate readings aren't poisoned [2571, 3085, 3599]. |
+| "check cliff / check for cliff" | ⚠️ Read grayscale, check if any channel <= 500. Validate reading first. |
+| "read grayscale / what are the grayscale values" | ⚠️ Create Grayscale_Module with direct ADC. Validate reading isn't poisoned before reporting. |
+| "detect QR code / scan QR" | `Vilib.qrcode_detect_switch(True) → read qr_data` |
+| "recognize gesture" | `Vilib.gesture_detect_switch(True) → read gesture_t` |
+| "detect traffic sign" | `Vilib.traffic_sign_detect_switch(True) → read traffic_sign_t` |
+
+Response style: When you successfully execute a command, briefly tell the user what happened in a friendly tone. e.g. "Driving forward 🚗" or "Turned right, the path looks clear" or "There's an obstacle 23 cm ahead."
+
+## exec Code Templates
+
+### Basic Movement — Drive Forward
+
+```python
+from picarx import Picarx
+from time import sleep
+car = Picarx()
+try:
+    car.forward(50)       # speed 0-100
+    sleep(1.0)            # adjust duration for distance
+finally:
+    car.stop()
+```
+
+### Basic Movement — Drive Backward
+
+```python
+from picarx import Picarx
+from time import sleep
+car = Picarx()
+try:
+    car.backward(50)
+    sleep(1.0)
+finally:
+    car.stop()
+```
+
+### Turn Left / Right
+
+```python
+from picarx import Picarx
+from time import sleep
+car = Picarx()
+try:
+    car.set_dir_servo_angle(-30)   # -30=left, 30=right
+    sleep(0.3)
+    car.forward(30)                # slow speed while turning
+    sleep(0.8)
+    car.set_dir_servo_angle(0)     # straighten wheels
+    sleep(0.3)
+finally:
+    car.stop()
+```
+
+### Adjust Camera Gimbal
+
+```python
+from picarx import Picarx
+car = Picarx()
+car.set_cam_pan_angle(60)     # range: -90 to 90
+# car.set_cam_tilt_angle(40)  # range: -35 to 65
+```
+
+To reset camera to center:
+```python
+car.set_cam_pan_angle(0)
+car.set_cam_tilt_angle(0)
+```
+
+### Read Ultrasonic Distance
+
+```python
+from picarx import Picarx
+car = Picarx()
+d = car.get_distance()
+print(f"{d:.1f}" if d else "None")
+```
+
+Parse `stdout` from exec output to get the distance value in cm.
+
+### Read Grayscale Sensor (Line Tracking / Cliff Detection)
+
+Use direct ADC and auto-calibrate the reference from a few samples:
+
+```python
+from robot_hat import ADC, Grayscale_Module
+from time import sleep
+adc0, adc1, adc2 = ADC("A0"), ADC("A1"), ADC("A2")
+
+# Auto-calibrate: sample a few readings, set reference to their midpoint
+gs = Grayscale_Module(adc0, adc1, adc2, reference=[200, 200, 200])
+sleep(0.3)
+samples = [gs.read() for _ in range(3)]
+# Reference = average of sampled values (midpoint between black line and white surface)
+ref = [sum(s[i] for s in samples) // len(samples) for i in range(3)]
+gs.reference(ref)
+print(f"Auto ref: {ref}")
+
+data = gs.read()
+print(f"Grayscale: {data}")
+```
+
+Check line status:
+```python
+status = gs.read_status(data)
+print(status)  # [0,0,0]=all_black, [0,1,0]=center_white=forward, etc.
+```
+
+Check cliff (any channel below threshold = cliff):
+```python
+is_cliff = any(data[i] <= 500 for i in range(3))
+print(f"Cliff detected: {is_cliff}")
+```
+
+### Play Sound Effects
+
+```python
+from robot_hat import Music
+music = Music()
+music.music_set_volume(50)
+music.sound_play('/path/to/sound.wav')
+# or non-blocking: music.sound_play_threading('/path/to/sound.wav')
+# or background music: music.music_play('/path/to/music.wav')
+```
+
+Set volume only:
+```python
+music.music_set_volume(80)  # 0-100
+```
+
+Stop playback:
+```python
+music.music_stop()
+```
+
+### Take a Photo
+
+```python
+from vilib import Vilib
+from time import sleep, strftime, localtime
+from os.path import expanduser
+Vilib.camera_start(vflip=False, hflip=False)
+Vilib.display(local=True, web=True)
+sleep(1)
+name = f"photo_{strftime('%Y-%m-%d-%H-%M-%S', localtime())}"
+Vilib.take_photo(name, expanduser('~/Pictures/'))
+Vilib.camera_close()
+print(f"saved: {expanduser('~/Pictures/')}{name}.jpg")
+```
+
+### Detect Faces
+
+```python
+from vilib import Vilib
+from time import sleep
+Vilib.camera_start(vflip=False, hflip=False)
+Vilib.display(local=True, web=True)
+sleep(1)
+Vilib.face_detect_switch(True)
+sleep(2)
+n = Vilib.detect_obj_parameter.get('human_n', 0)
+if n > 0:
+    x = Vilib.detect_obj_parameter.get('human_x')
+    y = Vilib.detect_obj_parameter.get('human_y')
+    print(f"Detected {n} face(s), center at ({x}, {y})")
+else:
+    print("No faces detected")
+Vilib.camera_close()
+```
+
+### Detect Colors
+
+```python
+from vilib import Vilib
+from time import sleep
+Vilib.camera_start(vflip=False, hflip=False)
+Vilib.display(local=True, web=True)
+sleep(1)
+Vilib.color_detect('red')   # options: red, orange, yellow, green, blue, purple, close
+sleep(2)
+n = Vilib.detect_obj_parameter.get('color_n', 0)
+if n > 0:
+    x = Vilib.detect_obj_parameter.get('color_x')
+    y = Vilib.detect_obj_parameter.get('color_y')
+    print(f"Detected {n} color block(s), center at ({x}, {y})")
+else:
+    print("No color blocks detected")
+Vilib.camera_close()
+```
+
+### QR Code / Gesture / Traffic Sign Detection
+
+```python
+from vilib import Vilib
+from time import sleep
+Vilib.camera_start(vflip=False, hflip=False)
+Vilib.display(local=True, web=True)
+sleep(1)
+Vilib.qrcode_detect_switch(True)         # QR codes
+# Vilib.gesture_detect_switch(True)      # rock/paper/scissor
+# Vilib.traffic_sign_detect_switch(True) # stop/left/right/forward
+sleep(2)
+
+# QR code result
+qr_data = Vilib.detect_obj_parameter.get('qr_data', '')
+if qr_data:
+    print(f"QR code: {qr_data}")
+else:
+    print("No QR code detected")
+
+# Gesture result
+# gesture_type = Vilib.detect_obj_parameter.get('gesture_t', '')
+# print(f"Gesture: {gesture_type}")
+
+# Traffic sign result
+# sign_type = Vilib.detect_obj_parameter.get('traffic_sign_t', '')
+# print(f"Traffic sign: {sign_type}")
+
+Vilib.camera_close()
+```
+
+### Line Tracking Loop (Continuous)
+
+Picarx first, then Grayscale_Module with auto-calibrated reference:
+
+```python
+from picarx import Picarx
+from robot_hat import ADC, Grayscale_Module
+from time import sleep
+
+# Order: Picarx FIRST (reset_mcu), then ADC — avoids poisoning
+car = Picarx()
+gs = Grayscale_Module(ADC("A0"), ADC("A1"), ADC("A2"), reference=[200, 200, 200])
+sleep(0.3)
+
+# Safety check + auto-calibrate reference from current surface
+if gs.read() == [2571, 3085, 3599]:
+    gs = Grayscale_Module(ADC("A0"), ADC("A1"), ADC("A2"), reference=[200, 200, 200])
+    sleep(0.3)
+samples = [gs.read() for _ in range(3)]
+ref = [sum(s[i] for s in samples) // len(samples) for i in range(3)]
+gs.reference(ref)
+print(f"Auto ref: {ref}")
+
+try:
+    for _ in range(50):  # adjust loop count
+        gm_data = gs.read()
+        if gm_data == [2571, 3085, 3599]:
+            continue      # skip poisoned reading
+        status = gs.read_status(gm_data)
+        if status == [0, 1, 0]:    # center on white → go forward
+            car.set_dir_servo_angle(0)
+            car.forward(30)
+        elif status == [1, 1, 0]:  # left on white → turn left
+            car.set_dir_servo_angle(25)
+            car.forward(30)
+        elif status == [0, 1, 1]:  # right on white → turn right
+            car.set_dir_servo_angle(-25)
+            car.forward(30)
+        else:                       # all black or all white → stop
+            car.stop()
+            break
+        sleep(0.05)
+finally:
+    car.stop()
+```
+
+## Typical Conversation Flow
+
+**User:** "drive forward"
+**AI executes:** the "Basic Movement — Drive Forward" template above
+**AI replies:** "Driving forward now 🚗"
+
+**User:** "turn left"
+**AI executes:** the "Turn Left / Right" template, with `set_dir_servo_angle(-30)`
+**AI replies:** "Turning left — path looks clear"
+
+**User:** "check if there's something ahead"
+**AI executes:** the "Read Ultrasonic Distance" template
+**AI replies:** "There's an obstacle about 23 cm ahead" / "The path is clear ahead"
+
+**User:** "look to the right"
+**AI executes:** the "Adjust Camera Gimbal" template with `set_cam_pan_angle(-60)`
+**AI replies:** "Looking to the right now"
+
+**User:** "take a photo"
+**AI executes:** the "Take a Photo" template
+**AI replies:** "Photo saved to ~/Pictures/photo_2026-01-15-14-30-22.jpg"
+
+**User:** "follow the line"
+**AI executes:** the "Line Tracking Loop" template
+**AI replies:** "Following the line... I'll stop if I lose track"
+
+## Full API Reference
+
+See `references/api.md` for all available methods:
+- `Picarx` — forward, backward, stop, set_dir_servo_angle, set_cam_pan_angle, set_cam_tilt_angle, get_distance, get_grayscale_data, get_line_status, get_cliff_status, set_power, reset, close
+- `Vilib` — camera_start, camera_close, display, take_photo, face_detect_switch, color_detect, qrcode_detect_switch, gesture_detect_switch, traffic_sign_detect_switch, detect_obj_parameter
+- `Music` — music_set_volume, sound_play, sound_play_threading, music_play, music_stop, music_pause, music_resume
+- `Ultrasonic` — read (returns cm)
+- `Grayscale_Module` — read, read_status, reference
+- `Pin`, `PWM`, `Servo`, `ADC` — low-level hardware control
+
+## Helper Script (Optional)
+
+There's also a CLI convenience script at `scripts/pc.py` — same functions, but prefer direct Python inline via exec for more control.

--- a/picarx-control/install.sh
+++ b/picarx-control/install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# PiCar-X Control Skill — One-click install script
+# Install all dependencies and deploy the skill on Raspberry Pi
+
+set -e
+
+echo "============================================"
+echo " PiCar-X Control Skill Installation"
+echo "============================================"
+
+# 1. Update system
+echo "[1/5] Updating system packages..."
+sudo apt update && sudo apt upgrade -y
+
+# 2. Install Python dependencies
+echo "[2/5] Installing Python tools..."
+sudo apt install -y git python3-pip python3-setuptools python3-smbus
+
+# 3. Install robot-hat
+echo "[3/5] Installing robot-hat..."
+cd ~
+if [ ! -d "robot-hat" ]; then
+    git clone -b v2.0 https://github.com/sunfounder/robot-hat.git --depth 1
+    cd robot-hat && sudo python3 install.py
+else
+    echo "   robot-hat already exists, skipping"
+fi
+
+# 4. Install vilib
+echo "[4/5] Installing vilib..."
+cd ~
+if [ ! -d "vilib" ]; then
+    git clone https://github.com/sunfounder/vilib.git --depth 1
+    cd vilib && sudo python3 install.py
+else
+    echo "   vilib already exists, skipping"
+fi
+
+# 5. Install picar-x
+echo "[5/5] Installing picar-x..."
+cd ~
+if [ ! -d "picar-x" ]; then
+    git clone https://github.com/sunfounder/picar-x.git --depth 1
+    cd picar-x && sudo python3 setup.py install
+else
+    echo "   picar-x already exists, skipping"
+fi
+
+# 6. Enable speaker (I2S)
+echo "[Optional] Enabling I2S speaker..."
+cd ~/robot-hat
+sudo bash i2samp.sh 2>/dev/null || echo "   Skipped (can be run manually later)"
+
+echo ""
+echo "============================================"
+echo " Installation complete!"
+echo ""
+echo "Usage:"
+echo "  python3 ~/picarx-control/scripts/pc.py --help"
+echo ""
+echo "Deploy to OpenClaw:"
+echo "  cp -r ~/picarx-control ~/.openclaw/workspace/skills/"
+echo "============================================"

--- a/picarx-control/references/api.md
+++ b/picarx-control/references/api.md
@@ -1,0 +1,299 @@
+# PiCar-X Python API Reference
+
+This is the reference for programming PiCar-X directly from Python.
+The OpenClaw AI agent should read this when it needs precise API signatures.
+
+## picarx.Picarx
+
+```python
+from picarx import Picarx
+car = Picarx(
+    servo_pins=['P0', 'P1', 'P2'],       # cam_pan, cam_tilt, dir_servo
+    motor_pins=['D4', 'D5', 'P13', 'P12'], # left_dir, right_dir, left_pwm, right_pwm
+    grayscale_pins=['A0', 'A1', 'A2'],    # 3-channel ADC
+    ultrasonic_pins=['D2', 'D3'],          # trig, echo
+    config='/opt/picar-x/picar-x.conf'
+)
+```
+
+Resets the MCU on init (~0.2s delay).
+
+### Constants
+
+| Constant | Value | Description |
+|---|---|---|
+| `DIR_MIN` | -30 | Minimum steering angle |
+| `DIR_MAX` | 30 | Maximum steering angle |
+| `CAM_PAN_MIN` | -90 | Minimum camera pan angle |
+| `CAM_PAN_MAX` | 90 | Maximum camera pan angle |
+| `CAM_TILT_MIN` | -35 | Minimum camera tilt angle |
+| `CAM_TILT_MAX` | 65 | Maximum camera tilt angle |
+
+### Movement
+
+#### forward(speed)
+Drive forward at the given speed (0-100).
+
+```python
+car.forward(50)
+sleep(1.0)
+car.stop()
+```
+
+#### backward(speed)
+Drive backward at the given speed (0-100).
+
+```python
+car.backward(50)
+sleep(1.0)
+car.stop()
+```
+
+#### set_power(speed)
+Set both motors to the same speed. Positive = forward, negative = backward.
+
+```python
+car.set_power(50)   # forward
+car.set_power(-50)  # backward
+```
+
+#### stop()
+Stop both motors immediately. Executes twice for reliability.
+
+```python
+car.stop()
+```
+
+#### set_motor_speed(motor, speed)
+Control individual motor speed.
+- `motor`: 1 = left motor, 2 = right motor
+- `speed`: -100 to 100 (negative = reverse)
+
+### Steering
+
+#### set_dir_servo_angle(value)
+Set the front steering servo angle. Range: -30 (left) to 30 (right).
+
+```python
+car.set_dir_servo_angle(-30)  # full left
+car.set_dir_servo_angle(0)    # center
+car.set_dir_servo_angle(30)   # full right
+```
+
+#### dir_servo_calibrate(value)
+Set and persist the steering servo calibration offset.
+
+```python
+car.dir_servo_calibrate(5)  # offset by +5 degrees
+```
+
+### Camera Gimbal
+
+#### set_cam_pan_angle(value)
+Rotate camera horizontally. Range: -90 (right) to 90 (left).
+
+```python
+car.set_cam_pan_angle(60)   # look left
+car.set_cam_pan_angle(-60)  # look right
+car.set_cam_pan_angle(0)    # center
+```
+
+#### set_cam_tilt_angle(value)
+Tilt camera vertically. Range: -35 (down) to 65 (up).
+
+```python
+car.set_cam_tilt_angle(40)   # look up
+car.set_cam_tilt_angle(-20)  # look down
+car.set_cam_tilt_angle(0)    # center
+```
+
+#### cam_pan_servo_calibrate(value)
+#### cam_tilt_servo_calibrate(value)
+Set and persist camera gimbal calibration offsets.
+
+### Sensors
+
+#### get_distance()
+Read the ultrasonic distance sensor. Returns distance in cm as float, or `None` if no echo received. May block up to timeout (0.02s default).
+
+```python
+d = car.get_distance()
+if d is not None:
+    print(f"Distance: {d:.1f} cm")
+```
+
+#### get_grayscale_data()
+Read the 3-channel grayscale module. Returns a list of 3 float values `[left, center, right]`. Lower values = darker surface (black line), higher values = lighter surface.
+
+```python
+data = car.get_grayscale_data()
+print(data)  # e.g. [200.5, 850.3, 210.1]
+```
+
+#### get_line_status(gm_val_list)
+Interpret grayscale data into a line-tracking direction.
+Returns one of: `"forward"`, `"left"`, `"right"`, `"stop"`.
+
+```python
+data = car.get_grayscale_data()
+status = car.get_line_status(data)
+```
+
+#### get_cliff_status(gm_val_list)
+Check if any grayscale channel value is below the cliff reference threshold.
+Returns `True` if a cliff/drop is detected, `False` otherwise.
+
+```python
+data = car.get_grayscale_data()
+if car.get_cliff_status(data):
+    print("Cliff detected! Stop!")
+    car.stop()
+```
+
+#### set_line_reference(value)
+#### set_cliff_reference(value)
+Set the reference thresholds for line tracking and cliff detection.
+Both take a list of 3 float values.
+
+```python
+car.set_line_reference([200, 800, 200])
+car.set_cliff_reference([500, 500, 500])
+```
+
+### Motor Calibration
+
+#### motor_speed_calibration(value)
+Adjust motor speed balance. Positive value compensates for right-drift, negative for left-drift.
+
+#### motor_direction_calibrate(motor, value)
+Set motor direction. `motor`: 1 or 2. `value`: 1 (normal) or -1 (reversed).
+
+### Lifecycle
+
+#### reset()
+Stop motors and reset all servos (steering, pan, tilt) to center.
+
+```python
+car.reset()
+```
+
+#### close()
+Reset and close the ultrasonic sensor. Call when done using the car.
+
+```python
+car.close()
+```
+
+## robot_hat.Ultrasonic
+
+```python
+from robot_hat import Ultrasonic, Pin
+sonar = Ultrasonic(Pin("D2"), Pin("D3"), timeout=0.02)
+distance = sonar.read()    # Returns cm as float, may block
+```
+
+Trigger on D2, echo on D3. The `read()` can block if no echo received.
+
+## robot_hat.Music
+
+```python
+from robot_hat import Music
+music = Music()
+
+music.music_set_volume(30)           # 0-100
+music.music_play(filename, loops=1, start=0.0, volume=None)
+music.music_stop()
+music.music_pause()
+music.music_resume()
+
+music.sound_play(filename, volume=None)            # Blocking SFX
+music.sound_play_threading(filename, volume=None)  # Non-blocking SFX
+
+music.play_tone_for(freq, duration)  # Play a tone at freq Hz for duration s
+```
+
+## robot_hat.Pin
+
+```python
+from robot_hat import Pin
+pin = Pin("D2")  # Digital pin by name
+```
+
+Common pin names on Robot HAT: `D0`–`D5`, `P0`–`P13`, `A0`–`A3`.
+
+## robot_hat.Grayscale_Module
+
+```python
+from robot_hat import Grayscale_Module, ADC
+adc0, adc1, adc2 = ADC("A0"), ADC("A1"), ADC("A2")
+gs = Grayscale_Module(adc0, adc1, adc2, reference=None)
+
+gs.reference([200, 800, 200])  # Set reference values
+data = gs.read()                # Read 3-channel values
+status = gs.read_status(data)   # Get line status string
+```
+
+## vilib.Vilib (Camera & Vision)
+
+```python
+from vilib import Vilib
+
+# Start camera and display
+Vilib.camera_start(vflip=False, hflip=False)
+Vilib.display(local=True, web=True)
+# Now visible at http://<pi-ip>:9000/mjpg
+
+# Detection switches
+Vilib.face_detect_switch(True|False)
+Vilib.color_detect('close'|'red'|'orange'|'yellow'|'green'|'blue'|'purple')
+Vilib.qrcode_detect_switch(True|False)
+Vilib.gesture_detect_switch(True|False)
+Vilib.traffic_sign_detect_switch(True|False)
+
+# Results in detect_obj_parameter dict:
+Vilib.detect_obj_parameter['color_x']     # Color block center X (0-320)
+Vilib.detect_obj_parameter['color_y']     # Color block center Y (0-240)
+Vilib.detect_obj_parameter['color_w']     # Color block width
+Vilib.detect_obj_parameter['color_h']     # Color block height
+Vilib.detect_obj_parameter['color_n']     # Number of color blocks
+
+Vilib.detect_obj_parameter['human_x']     # Face center X
+Vilib.detect_obj_parameter['human_y']     # Face center Y
+Vilib.detect_obj_parameter['human_w']     # Face width
+Vilib.detect_obj_parameter['human_h']     # Face height
+Vilib.detect_obj_parameter['human_n']     # Number of faces
+
+Vilib.detect_obj_parameter['gesture_x']   # Gesture X
+Vilib.detect_obj_parameter['gesture_y']   # Gesture Y
+Vilib.detect_obj_parameter['gesture_t']   # Type: paper|scissor|rock
+
+Vilib.detect_obj_parameter['traffic_sign_x']  # Sign X
+Vilib.detect_obj_parameter['traffic_sign_y']  # Sign Y
+Vilib.detect_obj_parameter['traffic_sign_t']  # Type: stop|right|left|forward
+
+Vilib.detect_obj_parameter['qr_data']     # QR decoded text
+Vilib.detect_obj_parameter['qr_x']        # QR X
+Vilib.detect_obj_parameter['qr_y']        # QR Y
+
+# Capture photo
+from time import strftime, localtime
+from os.path import expanduser
+name = f"photo_{strftime('%Y-%m-%d-%H-%M-%S', localtime())}"
+Vilib.take_photo(name, expanduser("~/Pictures/"))
+# Saved as ~/Pictures/photo_....jpg
+
+# Cleanup
+Vilib.camera_close()
+```
+
+## Wiring Info
+
+- Motors: L298N dual H-bridge via Robot HAT (D4/D5 direction, P13/P12 PWM)
+- Steering servo: PCA9685 channel P2
+- Camera pan servo: PCA9685 channel P0
+- Camera tilt servo: PCA9685 channel P1
+- Ultrasonic: Trig=D2, Echo=D3
+- Grayscale module: 3x ADC (A0, A1, A2)
+- Camera: PiCamera via CSI port
+- I2S audio: Built into Robot HAT
+- Power: 7-12V via Robot HAT barrel jack or 3-pin battery (18650 × 2)

--- a/picarx-control/scripts/pc.py
+++ b/picarx-control/scripts/pc.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+PiCar-X CLI — control the robot car from the command line.
+
+Usage:
+  pc.py move <action> [--steps N] [--speed N]
+  pc.py turn <direction> [--angle N]
+  pc.py cam <pan|tilt> --angle N
+  pc.py sensor <type>
+  pc.py sound play <file> [--volume N]
+  pc.py sound volume <0-100>
+  pc.py sound music <file> [--volume N]
+  pc.py sound stop
+  pc.py calibrate
+
+Examples:
+  pc.py move forward --speed 50
+  pc.py move backward --speed 40
+  pc.py turn left --angle 30
+  pc.py cam pan --angle 60
+  pc.py sensor distance
+  pc.py sensor grayscale
+  pc.py sound play ~/Music/horn.wav --volume 80
+  pc.py calibrate
+"""
+
+import argparse
+from time import sleep
+
+
+def cmd_move(args):
+    from picarx import Picarx
+    car = Picarx()
+    try:
+        if args.action == 'forward':
+            car.forward(args.speed)
+        elif args.action == 'backward':
+            car.backward(args.speed)
+        sleep(args.duration)
+    finally:
+        car.stop()
+
+
+def cmd_turn(args):
+    from picarx import Picarx
+    car = Picarx()
+    try:
+        angle = args.angle if args.direction == 'right' else -args.angle
+        car.set_dir_servo_angle(angle)
+        sleep(0.3)
+        car.forward(30)
+        sleep(0.8)
+        car.set_dir_servo_angle(0)
+        sleep(0.3)
+    finally:
+        car.stop()
+
+
+def cmd_cam(args):
+    from picarx import Picarx
+    car = Picarx()
+    if args.cam_action == 'pan':
+        car.set_cam_pan_angle(args.angle)
+    elif args.cam_action == 'tilt':
+        car.set_cam_tilt_angle(args.angle)
+
+
+def cmd_sensor(args):
+    if args.sensor_type == 'distance':
+        from picarx import Picarx
+        car = Picarx()
+        d = car.get_distance()
+        print(f"{d:.1f}" if d else "None")
+    elif args.sensor_type == 'grayscale':
+        from robot_hat import ADC, Grayscale_Module
+        adc0, adc1, adc2 = ADC("A0"), ADC("A1"), ADC("A2")
+        gs = Grayscale_Module(adc0, adc1, adc2, reference=[200, 200, 200])
+        sleep(0.3)
+        # Warmup + auto-calibrate reference from samples
+        samples = []
+        for i in range(5):
+            data = gs.read()
+            if data != [2571, 3085, 3599] and data[0] < 2000:
+                samples.append(data)
+            sleep(0.1)
+        if samples:
+            ref = [sum(s[i] for s in samples) // len(samples) for i in range(3)]
+            gs.reference(ref)
+            print(f"Auto ref: {ref}")
+            data = samples[-1]
+        else:
+            print(f"WARNING: ADC may be corrupted")
+            data = [0, 0, 0]
+        print(f"Grayscale: {data}")
+        status = gs.read_status(data)
+        print(f"Line status: {status}")
+        is_cliff = any(data[i] <= 500 for i in range(3))
+        print(f"Cliff detected: {is_cliff}")
+
+
+def cmd_sound(args):
+    from robot_hat import Music
+    music = Music()
+    if args.sound_cmd == 'play':
+        music.sound_play(args.file, volume=args.volume)
+    elif args.sound_cmd == 'volume':
+        music.music_set_volume(args.volume)
+    elif args.sound_cmd == 'music':
+        music.music_set_volume(args.volume or 20)
+        music.music_play(args.file)
+    elif args.sound_cmd == 'stop':
+        music.music_stop()
+
+
+def cmd_calibrate(args):
+    from picarx import Picarx
+    car = Picarx()
+    print("=== PiCar-X Servo Calibration ===")
+    print("This will help you calibrate the steering servo and camera gimbal.")
+    print("")
+
+    # Steering servo calibration
+    print("--- Steering Servo ---")
+    while True:
+        val = input("Enter steering offset (-30 to 30, or 'skip'): ").strip()
+        if val.lower() == 'skip':
+            break
+        try:
+            angle = int(val)
+            car.dir_servo_calibrate(angle)
+            print(f"  Steering set to {angle}. Is it centered? (y/n/skip): ", end='')
+            ok = input().strip().lower()
+            if ok == 'y':
+                break
+        except ValueError:
+            print("  Invalid input.")
+
+    # Camera pan servo calibration
+    print("--- Camera Pan Servo ---")
+    while True:
+        val = input("Enter camera pan offset (-90 to 90, or 'skip'): ").strip()
+        if val.lower() == 'skip':
+            break
+        try:
+            angle = int(val)
+            car.cam_pan_servo_calibrate(angle)
+            print(f"  Cam pan set to {angle}. Is it centered? (y/n/skip): ", end='')
+            ok = input().strip().lower()
+            if ok == 'y':
+                break
+        except ValueError:
+            print("  Invalid input.")
+
+    # Camera tilt servo calibration
+    print("--- Camera Tilt Servo ---")
+    while True:
+        val = input("Enter camera tilt offset (-35 to 65, or 'skip'): ").strip()
+        if val.lower() == 'skip':
+            break
+        try:
+            angle = int(val)
+            car.cam_tilt_servo_calibrate(angle)
+            print(f"  Cam tilt set to {angle}. Is it centered? (y/n/skip): ", end='')
+            ok = input().strip().lower()
+            if ok == 'y':
+                break
+        except ValueError:
+            print("  Invalid input.")
+
+    car.reset()
+    print("Calibration complete!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PiCar-X Robot Car Controller")
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+
+    # move
+    move_p = sub.add_parser("move", help="Drive the car")
+    move_p.add_argument("action", choices=["forward", "backward"])
+    move_p.add_argument("--speed", type=int, default=50, help="Speed 0-100")
+    move_p.add_argument("--duration", type=float, default=1.0, help="Duration in seconds")
+    move_p.set_defaults(func=cmd_move)
+
+    # turn
+    turn_p = sub.add_parser("turn", help="Turn the car")
+    turn_p.add_argument("direction", choices=["left", "right"])
+    turn_p.add_argument("--angle", type=int, default=30, help="Steering angle 0-30")
+    turn_p.set_defaults(func=cmd_turn)
+
+    # cam
+    cam_p = sub.add_parser("cam", help="Control camera gimbal")
+    cam_p.add_argument("cam_action", choices=["pan", "tilt"])
+    cam_p.add_argument("--angle", type=int, required=True, help="Angle (pan: -90~90, tilt: -35~65)")
+    cam_p.set_defaults(func=cmd_cam)
+
+    # sensor
+    sensor_p = sub.add_parser("sensor", help="Read sensors")
+    sensor_p.add_argument("sensor_type", choices=["distance", "grayscale"])
+    sensor_p.set_defaults(func=cmd_sensor)
+
+    # sound
+    sound_p = sub.add_parser("sound", help="Sound control")
+    sound_p.add_argument("sound_cmd", choices=["play", "volume", "music", "stop"])
+    sound_p.add_argument("file", nargs="?", help="Sound file path")
+    sound_p.add_argument("--volume", type=int, default=None, help="Volume 0-100")
+    sound_p.set_defaults(func=cmd_sound)
+
+    # calibrate
+    cali_p = sub.add_parser("calibrate", help="Run servo calibration")
+    cali_p.set_defaults(func=cmd_calibrate)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds the **PiCar-X control skill for OpenClaw**, replacing the previous GPT-4O/OpenAI-based approach with a modern OpenClaw integration.

## What's included

### New files
| File | Description |
|------|-------------|
| `picarx-control/SKILL.md` | Complete skill definition with code templates for all PiCar-X operations. Documents two critical rules: ADC poisoning prevention and reference auto-calibration. |
| `picarx-control/install.sh` | Dependency installation script |
| `picarx-control/scripts/pc.py` | CLI tool supporting `move`, `turn`, `cam`, `sensor` (distance/grayscale), `sound`, `calibrate` commands. Includes grayscale poison detection. |
| `picarx-control/references/api.md` | Complete PiCar-X API reference |

### Modified files
- `.gitignore` — Added `.claude/` and other secret exclusions

## Key technical finding
`Picarx.__init__()` calls `utils.reset_mcu()` which reboots the STM32 co-processor. If ADC objects already exist when this happens, the ADC is permanently poisoned and returns `[2571, 3085, 3599]` for all channels. The skill docs and CLI handle this correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)