### PR TITLE
feat: switch all voice_active_car examples to Piper TTS by default

### DIFF
--- a/example/21.voice_active_car_doubao_cn.py
+++ b/example/21.voice_active_car_doubao_cn.py
@@ -19,8 +19,26 @@ TOO_CLOSE = 10
 # 是否开启图像识别，需要使用多模态的大语言模型
 WITH_IMAGE = True
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from picarx.tts import Piper
+tts = Piper(model="zh_CN-huayan-x_low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from picarx.tts import EdgeTTS
+# tts = EdgeTTS(voice="zh-CN-XiaoxiaoNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from picarx.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from picarx.tts import Pico2Wave
+# tts = Pico2Wave()
+
 # 设置模型和语言
-TTS_MODEL = "zh_CN-huayan-x_low"
 STT_LANGUAGE = "cn"
 
 # 是否开启键盘输入
@@ -85,7 +103,7 @@ vac = VoiceActiveCar(
     too_close=TOO_CLOSE,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/example/21.voice_active_car_gpt.py
+++ b/example/21.voice_active_car_gpt.py
@@ -19,8 +19,26 @@ TOO_CLOSE = 10
 # Enable image, need to set up a multimodal language model
 WITH_IMAGE = True
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from picarx.tts import Piper
+tts = Piper(model="en_US-ryan-low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from picarx.tts import EdgeTTS
+# tts = EdgeTTS(voice="en-US-AriaNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from picarx.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from picarx.tts import Pico2Wave
+# tts = Pico2Wave()
+
 # Set models and languages
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Keyboard enable
@@ -84,7 +102,7 @@ vac = VoiceActiveCar(
     too_close=TOO_CLOSE,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/example/voice_active_car.py
+++ b/example/voice_active_car.py
@@ -23,7 +23,6 @@ WITH_IMAGE = True
 
 # Set models and languages
 LLM_MODEL = "gpt-4o-mini"
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Enable wake word


### PR DESCRIPTION
## Summary

Same TTS injection pattern as pidog PR #16 and picrawler. Switch voice_active_car examples from legacy `tts_model` parameter to TTS injection (`tts=tts`) with Piper as the default TTS engine.

## Changes

- **voice_active_car.py** (base class): Remove legacy `TTS_MODEL` variable
- **21.voice_active_car_gpt.py**: Add Piper TTS injection as default (en_US-ryan-low), comment out EdgeTTS/Espeak/Pico2Wave alternatives
- **21.voice_active_car_doubao_cn.py**: Add Piper TTS injection with `zh_CN-huayan-x_low` model, comment out alternatives

All examples now use `from picarx.tts import Piper` as the default TTS engine, with other TTS options available via uncommenting.

## Related

- pidog PR #16 (same pattern, merged)
- picrawler (same pattern, in progress)