### PR TITLE
fix(examples): disable local display in video/vision examples

### DIFF
--- a/example/11.video_car.py
+++ b/example/11.video_car.py
@@ -64,7 +64,7 @@ def main():
     status = 'stop'
 
     Vilib.camera_start(vflip=False,hflip=False)
-    Vilib.display(local=True,web=True)
+    Vilib.display(local=False,web=True)
     sleep(2)  # wait for startup
     print(manual)
     

--- a/example/7.computer_vision.py
+++ b/example/7.computer_vision.py
@@ -86,7 +86,7 @@ def main():
     qrcode_thread = None
 
     Vilib.camera_start(vflip=False,hflip=False)
-    Vilib.display(local=True,web=True)
+    Vilib.display(local=False,web=True)
     print(manual)
 
     while True:

--- a/example/9.record_video.py
+++ b/example/9.record_video.py
@@ -22,7 +22,7 @@ def main():
     Vilib.rec_video_set["path"] = f"/home/{username}/Videos/" # set path
 
     Vilib.camera_start(vflip=False,hflip=False)
-    Vilib.display(local=True,web=True)
+    Vilib.display(local=False,web=True)
     sleep(0.8)  # wait for startup
 
     print(manual)


### PR DESCRIPTION
Change \Vilib.display(local=True)\ to \local=False\ in three example files.

## What & Why

The \local=True\ setting opens a local preview window on the Raspberry Pi's physical display. When running the Pi headless (via SSH/VNC) or on a setup without an attached screen, this causes errors because there's no display output available.

## Changes

- \example/7.computer_vision.py\ — disable local display
- \example/9.record_video.py\ — disable local display  
- \example/11.video_car.py\ — disable local display

Web streaming (\web=True\) remains enabled in all cases, so users can still view the camera feed through the browser interface.