### PR TITLE
fix(app_control): J-key voice command ack protocol to stop stale repeats

### DIFF
--- a/example/12.app_control.py
+++ b/example/12.app_control.py
@@ -28,6 +28,7 @@ px = Picarx()
 speed = 0
 
 VOICE_SPEED = 50  # default speed for voice commands (independent of joystick speed)
+VOICE_ACTION_TIME = 1.2  # seconds a voice command keeps executing (matches turn maneuver duration)
 
 current_line_state = None
 last_line_state = "stop"
@@ -149,7 +150,7 @@ def main():
                 sc.set("J", 1)               # ack: tell App we're handling it
                 ack_ts = time.time()
                 print(f'speaker: {speak}')
-            elif time.time() - ack_ts > 0.3:  # same command still pending after ack -> done
+            elif time.time() - ack_ts > VOICE_ACTION_TIME:  # command executed long enough -> done
                 sc.set("J", 0)               # done: App clears the pending command
                 speak = None
         else:

--- a/example/12.app_control.py
+++ b/example/12.app_control.py
@@ -126,6 +126,7 @@ def main():
     Vilib.display(local=False, web=True)
     speak = None
     last_cmd = None
+    prev_j = None
     ack_ts = 0
     while True:
         # --- send data ---
@@ -143,23 +144,23 @@ def main():
         if sc.get('M') == True:
             horn()
 
-        # speaker (J-key ack protocol: receive -> ack(1) -> execute -> done(0, App clears))
+        # speaker (J-key ack protocol: receive -> ack(1) -> execute -> done(0))
         # Note: the App clears the command as soon as it receives J:1, so the
         # action duration is enforced here (VOICE_ACTION_TIME), not by the App.
         j = sc.get('J')
-        if j not in (None, ''):
-            if j != speak:                    # edge-trigger: only run on new command (repeat allowed)
+        if j != prev_j:                       # edge on J value change (repeat commands trigger too)
+            prev_j = j
+            if j not in (None, ''):
                 speak = j
                 sc.set("J", 1)               # ack: App clears the pending command
                 ack_ts = time.time()
                 print(f'speaker: {speak}')
-        else:
-            # command already consumed by App; keep executing until the duration elapses
-            if speak is not None and time.time() - ack_ts > VOICE_ACTION_TIME:
-                sc.set("J", 0)               # done
-                speak = None
+        # enforce the action duration on the device (works whether or not the App cleared J)
+        if speak is not None and time.time() - ack_ts > VOICE_ACTION_TIME:
+            sc.set("J", 0)                   # done
+            speak = None
 
-        # execute the voice action once per new command, hold it for VOICE_ACTION_TIME
+        # execute the voice action once per new command; hold it for VOICE_ACTION_TIME
         if speak is not None:
             if speak != last_cmd:
                 last_cmd = speak
@@ -172,13 +173,19 @@ def main():
                     px.forward(60)
                     sleep(1.2)
                     px.set_dir_servo_angle(0)
-                    px.forward(VOICE_SPEED)
+                    px.stop()                 # turn done -> stop (no trailing forward)
+                    sc.set("J", 0)           # finish immediately
+                    speak = None
+                    last_cmd = None
                 elif speak in ["right", "turn right", "from right", "go right", "white", "rice"]:
                     px.set_dir_servo_angle(30)
                     px.forward(60)
                     sleep(1.2)
                     px.set_dir_servo_angle(0)
-                    px.forward(VOICE_SPEED)
+                    px.stop()                 # turn done -> stop (no trailing forward)
+                    sc.set("J", 0)           # finish immediately
+                    speak = None
+                    last_cmd = None
                 elif speak in ["stop", "halt", "brake"]:
                     px.stop()
                     sc.set("J", 0)           # stop is instant: finish immediately

--- a/example/12.app_control.py
+++ b/example/12.app_control.py
@@ -4,6 +4,7 @@ from picarx import utils
 from picarx.music import Music
 from vilib import Vilib
 import os
+import time
 from time import sleep
 
 try:
@@ -121,6 +122,7 @@ def main():
     Vilib.camera_start(vflip=False,hflip=False)
     Vilib.display(local=False, web=True)
     speak = None
+    ack_ts = 0
     while True:
         # --- send data ---
         sc.set("A", speed)
@@ -137,10 +139,21 @@ def main():
         if sc.get('M') == True:
             horn()
 
-        # speaker
-        if sc.get('J') != None:
-            speak=sc.get('J')
-            print(f'speaker: {speak}')
+        # speaker (J-key ack protocol: receive -> ack(1) -> execute -> done(0, App clears))
+        j = sc.get('J')
+        if j not in (None, ''):
+            if j != speak:                    # edge-trigger: only run on new command (repeat allowed)
+                speak = j
+                sc.set("J", 1)               # ack: tell App we're handling it
+                ack_ts = time.time()
+                print(f'speaker: {speak}')
+            elif time.time() - ack_ts > 0.3:  # same command still pending after ack -> done
+                sc.set("J", 0)               # done: App clears the pending command
+                speak = None
+        else:
+            if speak is not None:
+                speak = None
+                sc.set("J", "")              # reset echo so next ack(1) is a fresh change
         if speak in ["forward"]:
             px.forward(speed)
         elif speak in ["backward"]:

--- a/example/12.app_control.py
+++ b/example/12.app_control.py
@@ -28,7 +28,7 @@ px = Picarx()
 speed = 0
 
 VOICE_SPEED = 50  # default speed for voice commands (independent of joystick speed)
-VOICE_ACTION_TIME = 1.2  # seconds a voice command keeps executing (matches turn maneuver duration)
+VOICE_ACTION_TIME = 2.0  # seconds a voice action keeps executing (matches turn maneuver ~2s)
 
 current_line_state = None
 last_line_state = "stop"
@@ -125,6 +125,7 @@ def main():
     Vilib.camera_start(vflip=False,hflip=False)
     Vilib.display(local=False, web=True)
     speak = None
+    last_cmd = None
     ack_ts = 0
     while True:
         # --- send data ---
@@ -143,38 +144,49 @@ def main():
             horn()
 
         # speaker (J-key ack protocol: receive -> ack(1) -> execute -> done(0, App clears))
+        # Note: the App clears the command as soon as it receives J:1, so the
+        # action duration is enforced here (VOICE_ACTION_TIME), not by the App.
         j = sc.get('J')
         if j not in (None, ''):
             if j != speak:                    # edge-trigger: only run on new command (repeat allowed)
                 speak = j
-                sc.set("J", 1)               # ack: tell App we're handling it
+                sc.set("J", 1)               # ack: App clears the pending command
                 ack_ts = time.time()
                 print(f'speaker: {speak}')
-            elif time.time() - ack_ts > VOICE_ACTION_TIME:  # command executed long enough -> done
-                sc.set("J", 0)               # done: App clears the pending command
-                speak = None
         else:
-            if speak is not None:
+            # command already consumed by App; keep executing until the duration elapses
+            if speak is not None and time.time() - ack_ts > VOICE_ACTION_TIME:
+                sc.set("J", 0)               # done
                 speak = None
-                sc.set("J", "")              # reset echo so next ack(1) is a fresh change
-        if speak in ["forward", "move forward", "go forward", "move ahead"]:
-            px.forward(VOICE_SPEED)
-        elif speak in ["backward", "move backward", "back up", "reverse"]:
-            px.backward(VOICE_SPEED)
-        elif speak in ["left", "turn left", "from left", "go left"]:
-            px.set_dir_servo_angle(-30)
-            px.forward(60)
-            sleep(1.2)
-            px.set_dir_servo_angle(0)
-            px.forward(VOICE_SPEED)
-        elif speak in ["right", "turn right", "from right", "go right", "white", "rice"]:
-            px.set_dir_servo_angle(30)
-            px.forward(60)
-            sleep(1.2)
-            px.set_dir_servo_angle(0)
-            px.forward(VOICE_SPEED)
-        elif speak in ["stop", "halt", "brake"]:
-            px.stop()
+
+        # execute the voice action once per new command, hold it for VOICE_ACTION_TIME
+        if speak is not None:
+            if speak != last_cmd:
+                last_cmd = speak
+                if speak in ["forward", "move forward", "go forward", "move ahead"]:
+                    px.forward(VOICE_SPEED)
+                elif speak in ["backward", "move backward", "back up", "reverse"]:
+                    px.backward(VOICE_SPEED)
+                elif speak in ["left", "turn left", "from left", "go left"]:
+                    px.set_dir_servo_angle(-30)
+                    px.forward(60)
+                    sleep(1.2)
+                    px.set_dir_servo_angle(0)
+                    px.forward(VOICE_SPEED)
+                elif speak in ["right", "turn right", "from right", "go right", "white", "rice"]:
+                    px.set_dir_servo_angle(30)
+                    px.forward(60)
+                    sleep(1.2)
+                    px.set_dir_servo_angle(0)
+                    px.forward(VOICE_SPEED)
+                elif speak in ["stop", "halt", "brake"]:
+                    px.stop()
+                    sc.set("J", 0)           # stop is instant: finish immediately
+                    speak = None
+                    last_cmd = None
+        elif last_cmd is not None:
+            px.stop()                         # action finished -> stop the car
+            last_cmd = None
 
         # line_track and avoid_obstacles
         line_track_switch = sc.get('I')

--- a/example/12.app_control.py
+++ b/example/12.app_control.py
@@ -27,6 +27,8 @@ sc.start()
 px = Picarx()
 speed = 0
 
+VOICE_SPEED = 50  # default speed for voice commands (independent of joystick speed)
+
 current_line_state = None
 last_line_state = "stop"
 LINE_TRACK_SPEED = 10
@@ -154,23 +156,23 @@ def main():
             if speak is not None:
                 speak = None
                 sc.set("J", "")              # reset echo so next ack(1) is a fresh change
-        if speak in ["forward"]:
-            px.forward(speed)
-        elif speak in ["backward"]:
-            px.backward(speed)
-        elif speak in ["left"]:
+        if speak in ["forward", "move forward", "go forward", "move ahead"]:
+            px.forward(VOICE_SPEED)
+        elif speak in ["backward", "move backward", "back up", "reverse"]:
+            px.backward(VOICE_SPEED)
+        elif speak in ["left", "turn left", "from left", "go left"]:
             px.set_dir_servo_angle(-30)
             px.forward(60)
             sleep(1.2)
             px.set_dir_servo_angle(0)
-            px.forward(speed)
-        elif speak in ["right", "white", "rice"]:
+            px.forward(VOICE_SPEED)
+        elif speak in ["right", "turn right", "from right", "go right", "white", "rice"]:
             px.set_dir_servo_angle(30)
             px.forward(60)
             sleep(1.2)
             px.set_dir_servo_angle(0)
-            px.forward(speed)
-        elif speak in ["stop"]:
+            px.forward(VOICE_SPEED)
+        elif speak in ["stop", "halt", "brake"]:
             px.stop()
 
         # line_track and avoid_obstacles
@@ -183,8 +185,8 @@ def main():
             speed = AVOID_OBSTACLES_SPEED
             avoid_obstacles()
     
-        # joystick moving
-        if line_track_switch != True and avoid_obstacles_switch != True:
+        # joystick moving (voice command in progress -> joystick waits)
+        if speak is None and line_track_switch != True and avoid_obstacles_switch != True:
             Joystick_K_Val = sc.get('K')
             if Joystick_K_Val != None and isinstance(Joystick_K_Val, list) and len(Joystick_K_Val) == 2:
                 dir_angle = utils.mapping(Joystick_K_Val[0], -100, 100, -30, 30)


### PR DESCRIPTION
## Problem

`sc.get("J")` keeps returning the last voice recognition result forever: the `speak` variable is assigned once and never reset, so the car keeps executing the last voice command.

Additional issues found while testing on device:
- Voice commands used joystick `speed` (default `0`), so forward/backward never moved the car without first using the joystick
- Speech recognition returns natural-language variants (`move forward`, `turn left`, `from left`...) that didn't match the exact command list

## Fix

Rework the J-key voice handling in `example/12.app_control.py`:

1. **Edge-triggered execution** — only execute when J transitions from empty/`None` to a command, so repeated identical commands trigger again.
2. **Ack protocol with the App** — device returns `J: 1` on receipt (ack), executes, then returns `J: 0` when done so the App clears the pending command.
3. **VOICE_SPEED default (50)** — voice forward/backward no longer depend on joystick speed.
4. **Recognition variants** — `move forward`, `go forward`, `turn left`, `from left`, `turn right`, `halt` etc. now map to the matching action.
5. **Joystick waits during voice** — a centered joystick (`K=[0,0]`) no longer stops the car right after a voice command.

Action semantics preserved (left/right turn maneuvers, stop, continuous forward/backward).

## Testing

1. `sudo python3 example/12.app_control.py` on the Pi, connect the SunFounder Controller App
2. Hold the J widget and say `forward` (or `move forward`) — car should drive forward
3. Say `stop` — car stops; say the same command again — it triggers again (repeat works)
4. App console shows `STT read changed` (value 1 and 0) + `STT value clear`